### PR TITLE
Slim down trogdor-load image

### DIFF
--- a/dockerfiles/load_generator/Dockerfile
+++ b/dockerfiles/load_generator/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:2.7-slim
 
 ENV INFLUXDB_HOST influxdb
 ENV INFLUXDB_PORT 8086
@@ -6,8 +6,10 @@ ENV INFLUXDB_USER root
 ENV INFLUXDB_PASSWORD root
 ENV INFLUXDB_NAME k8s
 
-RUN pip install locustio pyzmq influxdb
-RUN pip install --upgrade influxdb
+RUN apt-get update && apt-get install -y build-essential --no-install-recommends \
+    && pip install locustio pyzmq influxdb \
+    && pip install --upgrade influxdb \
+    && apt-get purge -y --auto-remove build-essential
 RUN ulimit -c -m -s -t unlimited
 COPY scripts /scripts
 


### PR DESCRIPTION
- Use a slim base image
- Install / purge build deps in a single RUN to reduce size